### PR TITLE
ctfd - update CTFd default version

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -40,7 +40,7 @@ variable "inbound_ips" {
 variable "ctfd_version" {
   type        = string
   description = "docker tag for CTFd version"
-  default     = "mark-3.3.1"
+  default     = "3.5.0"
 }
 
 variable "workers" {


### PR DESCRIPTION
update to latest, 3.5.0

https://hub.docker.com/layers/ctfd/ctfd/ctfd/3.5.0/images/sha256-baa3676416850e51d91981a966190a352f3695b1f11eca95f7ea2abefe1d9ddf?context=explore
https://github.com/CTFd/CTFd/releases/tag/3.5.0
