### PR TITLE
ecs - create task execution role instead of assuming it already exists

### DIFF
--- a/terraform/ecs/task_definition.tf
+++ b/terraform/ecs/task_definition.tf
@@ -2,17 +2,13 @@ locals {
   task_family_name = var.task_family_name
 }
 
-data "aws_iam_role" "ecsTaskExecutionRole" {
-  name = "ecsTaskExecutionRole"
-}
-
 resource "aws_ecs_task_definition" "task" {
   family             = local.task_family_name
   network_mode       = "awsvpc"
   cpu                = var.cpu
   memory             = var.memory
   execution_role_arn = var.execution_role_arn
-  task_role_arn      = data.aws_iam_role.ecsTaskExecutionRole.arn
+  task_role_arn      = aws_iam_role.ecs_task_execution.arn
 
   # race conditions FTL, gotta wait to make sure
   depends_on = [var.ecs_task_depends_on]

--- a/terraform/ecs/task_execution_role.tf
+++ b/terraform/ecs/task_execution_role.tf
@@ -1,0 +1,20 @@
+resource "aws_iam_role" "ecs_task_execution" {
+  name = "ecs-task-execution"
+
+  assume_role_policy = data.aws_iam_policy_document.ecs_task_execution_policy.json
+}
+
+data "aws_iam_policy_document" "ecs_task_execution_policy" {
+  statement {
+    sid    = "ECSAssumeRole"
+    effect = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+    actions = [
+      "sts:AssumeRole"
+    ]
+
+  }
+}


### PR DESCRIPTION
previously, we assumed the [ECS task execution role](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_execution_IAM_role.html#create-task-execution-role) existed and referenced it through a data block. Surprising nobody, that doesn't work when the role doesn't exist. Since I don't know a way to create a resource when a data block fails, I've decided to manage the role directly as part of the ECS module.
