### PR TITLE
ecs - provide more flexibility for desired_count

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,4 +1,4 @@
-module "ctfd_alb" { # TODO: update
+module "ctfd_alb" {
   source                  = "./alb"
   subnets                 = var.alb_subnets
   vpc_id                  = var.vpc_id
@@ -33,14 +33,17 @@ module "redis" {
 }
 
 module "ecs" {
-  source                    = "./ecs"
+  source = "./ecs"
+
+  # choose between desired_count from tfvars or matching the number of available subnets
+  desired_count = coalesce(var.desired_count, length(var.ecs_subnets))
+
   ctfd_version              = var.ctfd_version
   aws_access_key_arn        = module.iam.s3_access.arn
   aws_secret_access_key_arn = module.iam.s3_secret.arn
   mail_username_arn         = var.mail_username_arn
   mail_password_arn         = var.mail_password_arn
   database_url_arn          = module.mysql_db.db_uri.arn
-  desired_count             = length(var.ecs_subnets)
   workers                   = var.workers
   secret_key                = random_string.secret_key.result
   s3_bucket                 = module.s3_uploads.uploads_bucket.id

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -89,8 +89,9 @@ variable "allow_cloudflare" {
 }
 
 variable "desired_count" {
-  type        = number
+  type        = string
   description = "Number of instances of the task definition to place and keep running"
+  default     = ""
 }
 
 variable "db_subnets" {


### PR DESCRIPTION
use the  function to allow for desired_count customization; we can pass a static value via tfvars or accept the default aka the number of available subnets