### PR TITLE
terraform - naming things is hard

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,14 @@
 Build yourself some serverless infra to run [`ctfd`](https://github.com/CTFd/CTFd/) in AWS.
 
 ## Requirements
+
 - [`terraform`](https://www.terraform.io/) (this was built and tested with v1.2.2)
-- VPC and subnets for AWS resources
-- smtp server and credentials, such as [AWS SES](https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-smtp.html) or [Mailgun](https://www.mailgun.com/)
+- Existing VPC and subnet IDs for AWS resources
+- SMTP server and credentials, such as [AWS SES](https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-smtp.html) or [Mailgun](https://www.mailgun.com/)
+- Wildcard certificate managed by [AWS Certificate Manager](https://aws.amazon.com/certificate-manager/)
 
 ## Things To Know
-- This deployment does not support SSL by default. 
+
 - Secrets are expected to be stored in [SSM Parameter Store](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html) under the path `/ctfd/`.
 
 ## Architecture
@@ -21,7 +23,8 @@ Design choices have been documented and can be found in [`docs/adr`](docs/adr).
 ![architecture-diagram](image/CTFd-architecture.png)
 
 ## Usage
-Populate your `myvars.tf` file appropriately, then you're ready to go!
+Populate your `myvars.tfvars` file appropriately, then you're ready to go!
+
 ```
 ~ cat myvars.tfvars
 vpc_id        = "vpc-abc123"
@@ -39,4 +42,5 @@ mail_username_arn = "arn:aws:ssm:us-east-1:123456789123:parameter/ctfd/mail_user
 ~ terraform apply -var-files=myvars.tfvars
 ```
 
-NOTE: if you're looking for the older version that ran on VMs, you can find it [here](https://github.com/maxdotdotg/ctfd-infra/tree/ctfd-v2.5.0).
+## Where are the Virtual Machines?
+If you're looking for the older version that ran on VMs, you can find it [here](https://github.com/maxdotdotg/ctfd-infra/tree/ctfd-v2.5.0).

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -27,7 +27,6 @@
 
 | Name | Type |
 |------|------|
-| [random_string.bucket_seed](https://registry.terraform.io/providers/hashicorp/random/3.1.0/docs/resources/string) | resource |
 | [random_string.secret_key](https://registry.terraform.io/providers/hashicorp/random/3.1.0/docs/resources/string) | resource |
 
 ## Inputs
@@ -39,11 +38,12 @@
 | <a name="input_allow_cloudflare"></a> [allow\_cloudflare](#input\_allow\_cloudflare) | is cloudflare being used? | `bool` | `false` | no |
 | <a name="input_certificate_arn"></a> [certificate\_arn](#input\_certificate\_arn) | ARN for the SSL certificate used by the ALB | `string` | `""` | no |
 | <a name="input_create_aws_dns"></a> [create\_aws\_dns](#input\_create\_aws\_dns) | do you want to create DNS entries in route53? | `bool` | `false` | no |
-| <a name="input_ctfd_version"></a> [ctfd\_version](#input\_ctfd\_version) | docker tag for CTFd version | `string` | `"mark-3.3.1"` | no |
+| <a name="input_ctfd_version"></a> [ctfd\_version](#input\_ctfd\_version) | docker tag for CTFd version | `string` | `"3.5.0"` | no |
 | <a name="input_db_subnets"></a> [db\_subnets](#input\_db\_subnets) | subnets that the db nodes live in | `list(string)` | n/a | yes |
-| <a name="input_desired_count"></a> [desired\_count](#input\_desired\_count) | Number of instances of the task definition to place and keep running | `number` | n/a | yes |
+| <a name="input_desired_count"></a> [desired\_count](#input\_desired\_count) | Number of instances of the task definition to place and keep running | `string` | `""` | no |
 | <a name="input_ecs_subnets"></a> [ecs\_subnets](#input\_ecs\_subnets) | subnets used by the ECS service | `list(string)` | n/a | yes |
 | <a name="input_ecs_task_depends_on"></a> [ecs\_task\_depends\_on](#input\_ecs\_task\_depends\_on) | list of resources that have to be created first, avoiding race conditions | `any` | `null` | no |
+| <a name="input_env"></a> [env](#input\_env) | what environment are these resources being deployed to? | `string` | `"staging"` | no |
 | <a name="input_https_redirect_enabled"></a> [https\_redirect\_enabled](#input\_https\_redirect\_enabled) | is the https redirect enabled? | `bool` | `false` | no |
 | <a name="input_inbound_ips"></a> [inbound\_ips](#input\_inbound\_ips) | list of allowed inbound IP addresses | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
 | <a name="input_mail_password_arn"></a> [mail\_password\_arn](#input\_mail\_password\_arn) | SSM or ASM ARN for the username used to authenticate to the SMTP server | `string` | n/a | yes |
@@ -52,6 +52,7 @@
 | <a name="input_mail_username_arn"></a> [mail\_username\_arn](#input\_mail\_username\_arn) | SSM or ASM ARN for the username used to authenticate to the SMTP server | `string` | n/a | yes |
 | <a name="input_mailfrom_addr"></a> [mailfrom\_addr](#input\_mailfrom\_addr) | The email address that emails are sent from if not overridden in the configuration panel. | `string` | n/a | yes |
 | <a name="input_max_cpu_threshold"></a> [max\_cpu\_threshold](#input\_max\_cpu\_threshold) | n/a | `string` | `85` | no |
+| <a name="input_name_override"></a> [name\_override](#input\_name\_override) | a unique prefix for resource names | `string` | `""` | no |
 | <a name="input_region"></a> [region](#input\_region) | aws region the resources will be created in | `string` | n/a | yes |
 | <a name="input_route53_zone_id"></a> [route53\_zone\_id](#input\_route53\_zone\_id) | hosted zone id | `string` | `""` | no |
 | <a name="input_ssl_termination_enabled"></a> [ssl\_termination\_enabled](#input\_ssl\_termination\_enabled) | is SSL termination enabled? | `bool` | `false` | no |

--- a/terraform/alb/variables.tf
+++ b/terraform/alb/variables.tf
@@ -37,3 +37,9 @@ variable "allow_cloudflare" {
   description = "is cloudflare being used?"
   default     = false
 }
+
+variable "name_override" {
+  type        = string
+  default     = ""
+  description = "a unique prefix for resource names"
+}

--- a/terraform/ecs/autoscaling.tf
+++ b/terraform/ecs/autoscaling.tf
@@ -4,7 +4,7 @@
 module "ecs-service-autoscaling" {
   source                    = "cn-terraform/ecs-service-autoscaling/aws"
   version                   = "1.0.3"
-  ecs_cluster_name          = "ctfd-cluster"
+  ecs_cluster_name          = "${local.name}-cluster"
   ecs_service_name          = aws_ecs_service.ctfd.name
   name_prefix               = "ctfd"
   scale_target_min_capacity = var.desired_count

--- a/terraform/ecs/cluster.tf
+++ b/terraform/ecs/cluster.tf
@@ -1,5 +1,5 @@
 resource "aws_ecs_cluster" "cluster" {
-  name = "ctfd-cluster"
+  name = "${local.name}-cluster"
 
   setting {
     name  = "containerInsights"

--- a/terraform/ecs/locals.tf
+++ b/terraform/ecs/locals.tf
@@ -1,0 +1,4 @@
+locals {
+  # if name_override is not provided, use "ctfd", else append name_override to "ctfd"
+  name = var.name_override == "" ? "ctfd" : "ctfd-${var.name_override}"
+}

--- a/terraform/ecs/log_group.tf
+++ b/terraform/ecs/log_group.tf
@@ -1,3 +1,3 @@
 resource "aws_cloudwatch_log_group" "ctfd_logs" {
-  name = "/ecs/${local.task_family_name}"
+  name = "/ecs/${local.name}"
 }

--- a/terraform/ecs/service.tf
+++ b/terraform/ecs/service.tf
@@ -1,5 +1,5 @@
 resource "aws_ecs_service" "ctfd" {
-  name             = "ctfd-service"
+  name             = "${local.name}-service"
   cluster          = aws_ecs_cluster.cluster.id
   task_definition  = aws_ecs_task_definition.task.arn
   desired_count    = var.desired_count

--- a/terraform/ecs/task_definition.tf
+++ b/terraform/ecs/task_definition.tf
@@ -1,9 +1,5 @@
-locals {
-  task_family_name = var.task_family_name
-}
-
 resource "aws_ecs_task_definition" "task" {
-  family             = local.task_family_name
+  family             = local.name
   network_mode       = "awsvpc"
   cpu                = var.cpu
   memory             = var.memory
@@ -59,7 +55,7 @@ resource "aws_ecs_task_definition" "task" {
   requires_compatibilities = ["FARGATE"]
 
   tags = {
-    name         = local.task_family_name
+    name         = local.name
     ctfd_version = var.ctfd_version
   }
 

--- a/terraform/ecs/task_execution_role.tf
+++ b/terraform/ecs/task_execution_role.tf
@@ -1,5 +1,5 @@
 resource "aws_iam_role" "ecs_task_execution" {
-  name = "ecs-task-execution"
+  name = "${local.name}-ecs-task-execution"
 
   assume_role_policy = data.aws_iam_policy_document.ecs_task_execution_policy.json
 }

--- a/terraform/ecs/variables.tf
+++ b/terraform/ecs/variables.tf
@@ -126,3 +126,9 @@ variable "max_cpu_threshold" {
   type    = string
   default = "85"
 }
+
+variable "name_override" {
+  type        = string
+  default     = ""
+  description = "a unique prefix for resource names"
+}

--- a/terraform/iam/variables.tf
+++ b/terraform/iam/variables.tf
@@ -7,3 +7,9 @@ variable "region" {
   type        = string
   description = "aws region the resources will be created in"
 }
+
+variable "name_override" {
+  type        = string
+  default     = ""
+  description = "a unique prefix for resource names"
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -7,16 +7,19 @@ module "ctfd_alb" {
   allow_cloudflare        = var.allow_cloudflare
   inbound_ips             = var.inbound_ips
   certificate_arn         = var.certificate_arn
+  name_override           = var.name_override
 }
 
 module "iam" {
   source              = "./iam"
   uploads_bucket_name = module.s3_uploads.uploads_bucket.id
   region              = var.region
+  name_override       = var.name_override
 }
 
 module "s3_uploads" {
-  source = "./s3_uploads"
+  source        = "./s3_uploads"
+  name_override = var.name_override
 }
 
 module "mysql_db" {
@@ -24,12 +27,14 @@ module "mysql_db" {
   vpc_id            = var.vpc_id
   db_subnets        = var.db_subnets
   allocated_storage = var.allocated_storage
+  name_override     = var.name_override
 }
 
 module "redis" {
   source                   = "./redis"
   vpc_id                   = var.vpc_id
   snapshot_retention_limit = var.snapshot_retention_limit
+  name_override            = var.name_override
 }
 
 module "ecs" {
@@ -61,9 +66,10 @@ module "ecs" {
     module.mysql_db.db_security_group.id,
     module.ctfd_alb.alb_to_ecs_security_group.id
   ]
-  subnets = var.ecs_subnets
-  memory  = var.memory
-  cpu     = var.cpu
+  subnets       = var.ecs_subnets
+  memory        = var.memory
+  cpu           = var.cpu
+  name_override = var.name_override
 
   # wait for other resources in order to avoid race conditions :lolsob:
   ecs_task_depends_on = [module.mysql_db]

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -16,8 +16,7 @@ module "iam" {
 }
 
 module "s3_uploads" {
-  source              = "./s3_uploads"
-  uploads_bucket_name = "ctfd-uploads-${random_string.bucket_seed.result}"
+  source = "./s3_uploads"
 }
 
 module "mysql_db" {

--- a/terraform/mysql_db/variables.tf
+++ b/terraform/mysql_db/variables.tf
@@ -20,3 +20,9 @@ variable "allocated_storage" {
   default     = 10
   description = "GB of storage for the database"
 }
+
+variable "name_override" {
+  type        = string
+  default     = ""
+  description = "a unique prefix for resource names"
+}

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -18,6 +18,11 @@ terraform {
 
 provider "aws" {
   region = var.region
+  default_tags {
+    tags = {
+      env = var.env
+    }
+  }
 }
 
 provider "random" {}

--- a/terraform/redis/main.tf
+++ b/terraform/redis/main.tf
@@ -1,5 +1,11 @@
+locals {
+  # if name_override is not provided, use "ctfd", else append name_override to "ctfd"
+  name = var.name_override == "" ? "ctfd" : "ctfd-${var.name_override}"
+}
+
+
 resource "aws_elasticache_cluster" "cache" {
-  cluster_id               = "ctfd-cache"
+  cluster_id               = "${local.name}-cache"
   engine                   = "redis"
   node_type                = var.node_type
   num_cache_nodes          = 1
@@ -12,7 +18,7 @@ resource "aws_elasticache_cluster" "cache" {
 }
 
 resource "aws_security_group" "allow_redis" {
-  name        = "allow_redis"
+  name        = "${local.name} allow redis"
   description = "Allow redis inbound traffic"
   vpc_id      = var.vpc_id
 
@@ -32,7 +38,7 @@ resource "aws_security_group" "allow_redis" {
   }
 
   tags = {
-    Name = "allow_redis"
+    Name = "${local.name} allow redis"
   }
 }
 

--- a/terraform/redis/variables.tf
+++ b/terraform/redis/variables.tf
@@ -13,3 +13,9 @@ variable "snapshot_retention_limit" {
   type    = number
   default = 0
 }
+
+variable "name_override" {
+  type        = string
+  default     = ""
+  description = "a unique prefix for resource names"
+}

--- a/terraform/s3_uploads/main.tf
+++ b/terraform/s3_uploads/main.tf
@@ -1,9 +1,9 @@
 resource "aws_s3_bucket" "uploads_bucket" {
-  bucket = var.uploads_bucket_name
+  bucket = "${local.name}-${random_string.bucket_seed.result}"
   acl    = "private"
 
   tags = {
-    Name = var.uploads_bucket_name
+    Name = local.name
   }
 }
 
@@ -14,3 +14,7 @@ resource "aws_s3_bucket_public_access_block" "uploads_block" {
   block_public_policy = true
 }
 
+locals {
+  # if name_override is not provided, use "ctfd", else append name_override to "ctfd"
+  name = var.name_override == "" ? "ctfd" : "ctfd-${var.name_override}"
+}

--- a/terraform/s3_uploads/random.tf
+++ b/terraform/s3_uploads/random.tf
@@ -4,7 +4,6 @@ resource "random_string" "bucket_seed" {
   lower   = true
   special = false
 
-  # there's probably a better way to do this
   # the bucket_seed shouldn't change per deployment
   lifecycle {
     ignore_changes = all

--- a/terraform/s3_uploads/variables.tf
+++ b/terraform/s3_uploads/variables.tf
@@ -1,4 +1,5 @@
-variable "uploads_bucket_name" {
-  description = "name of the bucket for uploads"
+variable "name_override" {
   type        = string
+  default     = ""
+  description = "a unique prefix for resource names"
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -142,3 +142,9 @@ variable "snapshot_retention_limit" {
   type    = number
   default = 0
 }
+
+variable "env" {
+  type        = string
+  default     = "staging"
+  description = "what environment are these resources being deployed to?"
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -148,3 +148,8 @@ variable "env" {
   default     = "staging"
   description = "what environment are these resources being deployed to?"
 }
+
+variable "name_override" {
+  default     = ""
+  description = "a unique prefix for resource names"
+}


### PR DESCRIPTION
this PR provides a `name_override` variable for customizing resource names in the event of running two deployments of CTFd in the same region. There's probably more work to do, but this gets the job done for now.