### PR TITLE
ecs - add reverse_proxy env var

### DIFF
--- a/terraform/ecs/task_definition.tf
+++ b/terraform/ecs/task_definition.tf
@@ -25,15 +25,16 @@ resource "aws_ecs_task_definition" "task" {
       ],
 
       "environment" : [
-        { "name" : "WORKERS", "value" : "${var.workers}" },
-        { "name" : "SECRET_KEY", "value" : "${var.secret_key}" },
         { "name" : "AWS_S3_BUCKET", "value" : "${var.s3_bucket}" },
         { "name" : "MAILFROM_ADDR", "value" : "${var.mailfrom_addr}" },
         { "name" : "MAIL_SERVER", "value" : "${var.mail_server}" },
         { "name" : "MAIL_PORT", "value" : "${var.mail_port}" },
-        { "name" : "REDIS_URL", "value" : "redis://${var.redis_url}" },
-        { "name" : "UPLOAD_PROVIDER", "value" : "s3" },
         { "name" : "MAIL_USEAUTH", "value" : "true" },
+        { "name" : "REDIS_URL", "value" : "redis://${var.redis_url}" },
+        { "name" : "REVERSE_PROXY", "value" : "true" },
+        { "name" : "SECRET_KEY", "value" : "${var.secret_key}" },
+        { "name" : "UPLOAD_PROVIDER", "value" : "s3" },
+        { "name" : "WORKERS", "value" : "${var.workers}" },
       ],
 
       logConfiguration = {


### PR DESCRIPTION
since the deployment uses an application load balancer for load balancing, TLS termination, and as a reverse proxy, the application should adjust it's logs accordingly. to that end, I've (finally) set the [`REVERSE_PROXY`](https://docs.ctfd.io/docs/deployment/configuration#reverse_proxy) env var.
