### PR TITLE
iam - add delete object permisison to ECS role

### DIFF
--- a/terraform/iam/main.tf
+++ b/terraform/iam/main.tf
@@ -28,6 +28,7 @@ resource "aws_iam_policy" "s3_policy" {
           "s3:Put*",
           "s3:Get*",
           "s3:List*",
+          "s3:DeleteObject"
         ]
         Effect = "Allow"
         Resource = [


### PR DESCRIPTION
This PR adds the DeleteObject permission to the S3 role used to manage assets in CTFd. Now, we can remove bad files through the UI!
